### PR TITLE
Correction to provide full 16 bit address for ALL IO operations 

### DIFF
--- a/src/main/java/com/codingrodent/microprocessor/IBaseDevice.java
+++ b/src/main/java/com/codingrodent/microprocessor/IBaseDevice.java
@@ -22,7 +22,8 @@ public interface IBaseDevice {
     /**
      * Read data from an I/O port
      *
-     * @param address The port to be read from
+     * @param address The address contains the full 16 bit address
+     *                The port to be read from is contained in the lower 8 bits
      * @return The 8 bit value at the request port address
      */
     default int IORead(int address) {
@@ -32,7 +33,8 @@ public interface IBaseDevice {
     /**
      * Write data to an I/O port
      *
-     * @param address The port to be written to
+     * @param address The address contains the full 16 bit address
+     *                The port to be read from is contained in the lower 8 bits
      * @param data    The 8 bit value to be written
      */
     default void IOWrite(int address, int data) {

--- a/src/main/java/com/codingrodent/microprocessor/Z80/Z80Core.java
+++ b/src/main/java/com/codingrodent/microprocessor/Z80/Z80Core.java
@@ -6174,16 +6174,21 @@ public class Z80Core implements ICPUData {
 
     /* IN A,(NN) */
     private void inAN() {
-        reg_A = io.IORead(ram.readByte(reg_PC));
+        reg_A = io.IORead(getInOutAddressRegA());
         incPC();
         reg_R++;
     }
 
     /* OUT (NN),A */
     private void outNA() {
-        io.IOWrite(ram.readByte(reg_PC), reg_A);
+        io.IOWrite(getInOutAddressRegA(), reg_A);
         incPC();
         reg_R++;
+    }
+
+    private int getInOutAddressRegA() {
+        // high order address bits from A reg - for IN,OUT A
+        return (reg_A << 8) + ram.readByte(reg_PC);
     }
 
     /* IN rr,(c) */
@@ -6492,7 +6497,7 @@ public class Z80Core implements ICPUData {
 
     /* block IO */
     private void INI() {
-        ram.writeByte(getHL(), io.IORead(reg_C));
+        ram.writeByte(getHL(), io.IORead(getBC()));
         reg_B = (reg_B - 1) & lsb;
         setHL(ALU16BitInc(getHL()));
         setZ(reg_B == 0);
@@ -6507,7 +6512,7 @@ public class Z80Core implements ICPUData {
     }
 
     private void IND() {
-        ram.writeByte(getHL(), io.IORead(reg_C));
+        ram.writeByte(getHL(), io.IORead(getBC()));
         reg_B = (reg_B - 1) & lsb;
         setHL(ALU16BitDec(getHL()));
         setZ(reg_B == 0);
@@ -6522,7 +6527,7 @@ public class Z80Core implements ICPUData {
     }
 
     private void OUTI() {
-        io.IOWrite(reg_C, ram.readByte(getHL()));
+        io.IOWrite(getBC(), ram.readByte(getHL()));
         reg_R++;
         reg_B = (reg_B - 1) & lsb;
         setHL(ALU16BitInc(getHL()));
@@ -6538,7 +6543,7 @@ public class Z80Core implements ICPUData {
     }
 
     private void OUTD() {
-        io.IOWrite(reg_C, ram.readByte(getHL()));
+        io.IOWrite(getBC(), ram.readByte(getHL()));
         reg_R++;
         reg_B = (reg_B - 1) & lsb;
         setHL(ALU16BitDec(getHL()));


### PR DESCRIPTION
Correction to provide full 16 bit address for ALL IO operations as per Z80 specification. This was partially implemented on some IO operations, but not all. All IO operations now provide 16 bit addresses. 16 bit addressing is used predominantly in Spectrum hardware for keyboard interfacing.